### PR TITLE
Coerce Ruby socket.fileno into real Windows sockets

### DIFF
--- a/ext/libssh2_ruby_c/libssh2_ruby.h
+++ b/ext/libssh2_ruby_c/libssh2_ruby.h
@@ -20,6 +20,16 @@
 } while (0)
 
 /*
+ * Convert Ruby socket's fileno into real Windows sockets that can be used
+ * with LibSSH2. This is a no-op for any other OS.
+ * */
+#ifdef _WIN32
+# define TO_SOCKET(x) _get_osfhandle(x)
+#else
+# define TO_SOCKET(x) x
+#endif
+
+/*
  * Macro that handles generic libssh2 return values as we normally
  * do throughout the library: return true for success, and raise an
  * exception for any errors.

--- a/ext/libssh2_ruby_c/session.c
+++ b/ext/libssh2_ruby_c/session.c
@@ -118,7 +118,7 @@ block_directions(VALUE self) {
 static VALUE
 handshake(VALUE self, VALUE num_fd) {
     int fd = NUM2INT(num_fd);
-    int ret = libssh2_session_handshake(get_session(self), fd);
+    int ret = libssh2_session_handshake(get_session(self), TO_SOCKET(fd));
     HANDLE_LIBSSH2_RESULT(ret);
 }
 


### PR DESCRIPTION
This coercion is required to pass a real socket into libssh2 function. It
becomes a no-op for other operating systems.
